### PR TITLE
add sample form

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,2 +1,3 @@
 makensonregistrationapp.title=Makensonregistrationapp
 makensonregistrationapp.refapp.title=Makensonregistrationapp Reference Application
+makensonregistrationapp.sampleform.label=Sample Form

--- a/omod/src/main/resources/apps/sample_form_app.json
+++ b/omod/src/main/resources/apps/sample_form_app.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "sampleform",
+    "label": "Sample form",
+    "description": "Opens the sample form",
+    "extensions": [
+      {
+        "id": "patientDashboard.visitActions.sampleform",
+        "extensionPointId": "patientDashboard.visitActions",
+        "type": "link",
+        "label": "makensonregistrationapp.sampleform.label",
+        "url": "htmlformentryui/htmlform/enterHtmlFormWithStandardUi.page?patientId={{patient.uuid}}&visitId={{visit.id}}&definitionUiResource=makensonregistrationapp:htmlforms/sample.xml",
+        "icon": "icon-user",
+        "order": 1
+      }
+    ]
+  }
+]

--- a/omod/src/main/webapp/resources/htmlforms/sample.xml
+++ b/omod/src/main/webapp/resources/htmlforms/sample.xml
@@ -1,0 +1,7 @@
+<!-- form encounter type is uuid of "Check-In" encounter type installs as part of ref app -->
+<!-- form uuid is a randon uuid generated here: -->
+<htmlform formUuid="e8d63aeb-9cce-40fa-9a38-b81b9bb65876" formName="Sample"
+          formEncounterType="ca3aed11-1aa4-42a1-b85c-8332fc8001fc" formVersion="1.0">
+    <encounterDate></encounterDate>
+    <encounterLocation></encounterLocation>
+</htmlform>


### PR DESCRIPTION
@koolstens here's an example of adding a basic form and app config to make a link for that form to show up on the visit dashboard.

This also allows you to add forms and configuration code, which makes it easier for us to go back-and-forth reviewing and working on them.
